### PR TITLE
CreateGroup() returns INVALID_ARGUMENT if the parent is empty; the description can be empty.

### DIFF
--- a/ovgs.proto
+++ b/ovgs.proto
@@ -244,7 +244,7 @@ message GetOwnershipVoucherResponse {
 service OwnershipVoucherService {
   // CreateGroup creates a group as a child of an existing group.
   // Errors will be returned:
-  // INVALID_ARGUMENT if the description is empty
+  // INVALID_ARGUMENT if the parent is empty
   // NOT_FOUND if the parent group doesn't exist, as specified in request
   // PERMISSION_DENIED if the user doesn't have access to the parent group
   // Roles with permission to invoke this = ADMIN

--- a/ovgs.proto
+++ b/ovgs.proto
@@ -244,7 +244,7 @@ message GetOwnershipVoucherResponse {
 service OwnershipVoucherService {
   // CreateGroup creates a group as a child of an existing group.
   // Errors will be returned:
-  // INVALID_ARGUMENT if the parent is empty
+  // INVALID_ARGUMENT if either parent or description is empty
   // NOT_FOUND if the parent group doesn't exist, as specified in request
   // PERMISSION_DENIED if the user doesn't have access to the parent group
   // Roles with permission to invoke this = ADMIN


### PR DESCRIPTION
Harshit, I think this is what was intended, but I suppose it is possible that you mean to require both fields be non-empty.